### PR TITLE
Hide arrows by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import ReactCarouselQuery from 'react-carousel-query';
 ### Props
 - `fetchStep`: Number of items requested in each GET call (optional, default is 3)
 - `hideIndex`: Avoid displaying in desktop devices the index on top right corner (optional, default is false)
-- `showArrowsOnMobile`: Show arrows on mobile (optional, default is false)
+- `showArrows`: Show arrows (optional, default is false)
 - `renderBadge`: Render the badge component as you wish. (optional)
 - `renderArrow`: Render the arrow component as you wish. (optional, see [example](https://repl.it/@pedrocostadev/react-carousel-query-custom-arrows))
 - `renderItem`: Render each slide as you wish! You can even render more than one at once using the `getData` prop.

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare module 'react-carousel-query' {
       renderBadge?: () => React.ReactElement;
       fetchStep?: number;
       hideIndex?: boolean;
-      showArrowsOnMobile?: boolean;
+      showArrows?: boolean;
     }
   
     const ReactCarouselQuery: React.FC<ReactCarouselQueryProps>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carousel-query",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "A infinite carousel component made with react that handles the pagination for you.",
   "keywords": ["React", "Carousel", "Infinite", "Query", "Slides"],
   "main": "dist/index.js",

--- a/src/components/arrow/__snapshots__/arrow.test.js.snap
+++ b/src/components/arrow/__snapshots__/arrow.test.js.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <button
         class="arrowButton left"
-        data-testid="button-left"
+        data-testid="arrow-button-left"
       >
         <svg
           fill="none"
@@ -30,7 +30,7 @@ Object {
   "container": <div>
     <button
       class="arrowButton left"
-      data-testid="button-left"
+      data-testid="arrow-button-left"
     >
       <svg
         fill="none"

--- a/src/components/arrow/arrow.js
+++ b/src/components/arrow/arrow.js
@@ -7,18 +7,16 @@ import Button from '@primitives/button';
 
 import styles from './arrow.module.css';
 
-const Arrow = ({ variant, showOnMobile, renderArrow, ...buttonProps }) => {
+const Arrow = ({ variant, renderArrow, ...buttonProps }) => {
   if (typeof renderArrow === 'function') {
     return renderArrow({ variant, ...buttonProps });
   }
 
   return (
     <Button
-      data-testid={`button-${variant}`}
+      data-testid={`arrow-button-${variant}`}
       {...buttonProps}
-      className={classnames(styles.arrowButton, styles[variant], {
-        [styles.showOnMobile]: showOnMobile,
-      })}
+      className={classnames(styles.arrowButton, styles[variant])}
     >
       <IconChevron />
     </Button>

--- a/src/components/arrow/arrow.module.css
+++ b/src/components/arrow/arrow.module.css
@@ -19,12 +19,6 @@
 	cursor:pointer;
 }
 
-@media only screen and (max-width: 768px) {
-	.arrowButton:not(.showOnMobile) {
-		display: none;
-	}
-}
-
 .right {
 	right: 1px;
 }

--- a/src/components/arrow/arrow.test.js
+++ b/src/components/arrow/arrow.test.js
@@ -47,17 +47,4 @@ describe('<Arrow />', () => {
     const arrowButton = getByTestId('arrowRight');
     expect(arrowButton.classList.contains('right')).toBe(true);
   });
-
-  test('It should have showOnMobile class when prop is passed', () => {
-    const { getByTestId } = render(
-      <Arrow
-        showOnMobile
-        data-testid="arrow-left"
-        variant="left"
-        onClick={onClick}
-      />,
-    );
-    const arrowButton = getByTestId('arrow-left');
-    expect(arrowButton.classList.contains('showOnMobile')).toBe(true);
-  });
 });

--- a/src/components/carouselItemsContainer/__snapshots__/carouselItemsContainer.test.js.snap
+++ b/src/components/carouselItemsContainer/__snapshots__/carouselItemsContainer.test.js.snap
@@ -2,26 +2,6 @@
 
 exports[`<CarouselItemsContainer /> It should hide index 1`] = `
 <div>
-  <button
-    class="arrowButton left"
-    data-testid="button-left"
-  >
-    <svg
-      fill="none"
-      fill-rule="evenodd"
-      height="15"
-      preserveAspectRatio="xMidYMax meet"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      viewBox="-.2 -.3 8 5"
-      width="40"
-    >
-      <polyline
-        points="1 1 3.77984472 4 6.53846154 1"
-      />
-    </svg>
-  </button>
   <div
     class="container flexDisplay alignCenter fullHeight"
     style="transform: translateX(0px); transition-duration: 0s;"
@@ -41,26 +21,33 @@ exports[`<CarouselItemsContainer /> It should hide index 1`] = `
       </p>
     </div>
   </div>
-  <button
-    class="arrowButton right"
-    data-testid="button-right"
+</div>
+`;
+
+exports[`<CarouselItemsContainer /> It should not render the arrows by default 1`] = `
+<div>
+  <span>
+    1/2
+  </span>
+  <div
+    class="container flexDisplay alignCenter fullHeight"
+    style="transform: translateX(0px); transition-duration: 0s;"
   >
-    <svg
-      fill="none"
-      fill-rule="evenodd"
-      height="15"
-      preserveAspectRatio="xMidYMax meet"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      viewBox="-.2 -.3 8 5"
-      width="40"
+    <div
+      class="container fullHeight fullWidth fullMaxHeight fullMinWidth"
     >
-      <polyline
-        points="1 1 3.77984472 4 6.53846154 1"
-      />
-    </svg>
-  </button>
+      <p>
+        first
+      </p>
+    </div>
+    <div
+      class="container fullHeight fullWidth fullMaxHeight fullMinWidth"
+    >
+      <p>
+        second
+      </p>
+    </div>
+  </div>
 </div>
 `;
 
@@ -69,9 +56,36 @@ exports[`<CarouselItemsContainer /> It should render 1`] = `
   <span>
     1/2
   </span>
+  <div
+    class="container flexDisplay alignCenter fullHeight"
+    style="transform: translateX(0px); transition-duration: 0s;"
+  >
+    <div
+      class="container fullHeight fullWidth fullMaxHeight fullMinWidth"
+    >
+      <p>
+        first
+      </p>
+    </div>
+    <div
+      class="container fullHeight fullWidth fullMaxHeight fullMinWidth"
+    >
+      <p>
+        second
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<CarouselItemsContainer /> It should render the arrows when showArrows prop is true 1`] = `
+<div>
+  <span>
+    1/2
+  </span>
   <button
     class="arrowButton left"
-    data-testid="button-left"
+    data-testid="arrow-button-left"
   >
     <svg
       fill="none"
@@ -110,7 +124,7 @@ exports[`<CarouselItemsContainer /> It should render 1`] = `
   </div>
   <button
     class="arrowButton right"
-    data-testid="button-right"
+    data-testid="arrow-button-right"
   >
     <svg
       fill="none"

--- a/src/components/carouselItemsContainer/carouselItemsContainer.js
+++ b/src/components/carouselItemsContainer/carouselItemsContainer.js
@@ -20,7 +20,7 @@ const CarouselItemsContainer = ({
   renderItem,
   renderBadge,
   hideIndex,
-  showArrowsOnMobile,
+  showArrows,
 }) => {
   const containerRef = React.useRef(null);
 
@@ -157,12 +157,9 @@ const CarouselItemsContainer = ({
           total={total}
         />
       )}
-      <Arrow
-        renderArrow={renderArrow}
-        variant="left"
-        showOnMobile={showArrowsOnMobile}
-        onClick={onPrevious}
-      />
+      {showArrows && (
+        <Arrow renderArrow={renderArrow} variant="left" onClick={onPrevious} />
+      )}
       <FlexContainer
         ref={containerRef}
         fullHeight
@@ -184,12 +181,9 @@ const CarouselItemsContainer = ({
           <CarouselItem key={item.id} item={item} renderItem={renderItem} />
         ))}
       </FlexContainer>
-      <Arrow
-        renderArrow={renderArrow}
-        variant="right"
-        showOnMobile={showArrowsOnMobile}
-        onClick={onNext}
-      />
+      {showArrows && (
+        <Arrow renderArrow={renderArrow} variant="right" onClick={onNext} />
+      )}
     </>
   );
 };
@@ -199,7 +193,7 @@ CarouselItemsContainer.propTypes = {
   renderItem: PropTypes.func.isRequired,
   renderBadge: PropTypes.func,
   hideIndex: PropTypes.bool,
-  showArrowsOnMobile: PropTypes.bool,
+  showArrows: PropTypes.bool,
 };
 
 export default CarouselItemsContainer;

--- a/src/components/carouselItemsContainer/carouselItemsContainer.test.js
+++ b/src/components/carouselItemsContainer/carouselItemsContainer.test.js
@@ -44,4 +44,30 @@ describe('<CarouselItemsContainer />', () => {
     expect(getByText('first')).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
+
+  test('It should not render the arrows by default', () => {
+    const { container, queryByTestId } = render(
+      <CarouselItemsContainer {...props} />,
+    );
+
+    const leftArrowButton = queryByTestId('arrow-button-left');
+    const rightArrowButton = queryByTestId('arrow-button-right');
+
+    expect(leftArrowButton).toBeFalsy();
+    expect(rightArrowButton).toBeFalsy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('It should render the arrows when showArrows prop is true', () => {
+    const { container, getByTestId } = render(
+      <CarouselItemsContainer showArrows {...props} />,
+    );
+
+    const leftArrowButton = getByTestId('arrow-button-left');
+    const rightArrowButton = getByTestId('arrow-button-right');
+
+    expect(leftArrowButton).toBeTruthy();
+    expect(rightArrowButton).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/reactCarouselQuery/reactCarouselQuery.js
+++ b/src/components/reactCarouselQuery/reactCarouselQuery.js
@@ -24,7 +24,7 @@ ReactCarouselQuery.propTypes = {
   getData: PropTypes.func.isRequired,
   fetchStep: PropTypes.number,
   hideIndex: PropTypes.bool,
-  showArrowsOnMobile: PropTypes.bool,
+  showArrows: PropTypes.bool,
 };
 
 export default ReactCarouselQuery;


### PR DESCRIPTION
With this [PR](https://github.com/pedrocostadev/react-carousel-query/pull/9) we start supporting sliding in desktop devices as we do on mobile ones so does not make sense to display the arrows by default.
This PR hides the arrows by default and converts the prop `showArrowsOnMobile` to `showArrows`. The decision to show or not them is up with the developers.